### PR TITLE
Fix duplicate notifications in painel.js Socket.IO events

### DIFF
--- a/static/ti/js/painel/painel.js
+++ b/static/ti/js/painel/painel.js
@@ -2732,11 +2732,16 @@ document.querySelectorAll('.modal').forEach(modal => {
 
 // Configuração do Socket.IO
 let socket = null;
+let painelSocketInitialized = false;
 
 function initializeSocketIO() {
     try {
+        if (painelSocketInitialized && socket) {
+            console.log('Socket.IO do painel já inicializado, ignorando nova inicialização');
+            return;
+        }
         console.log('Inicializando Socket.IO...');
-        
+
         socket = io({
             transports: ['websocket', 'polling'],
             timeout: 20000,
@@ -2786,19 +2791,12 @@ function initializeSocketIO() {
         // Event listeners para notificações
         socket.on('notification_test', function(data) {
             console.log('Teste de notificação recebido:', data);
-            if (window.advancedNotificationSystem) {
-                window.advancedNotificationSystem.showInfo('Teste Socket.IO', data.message);
-            }
+            // Notificação visual já é tratada em notificacoes.js
         });
 
         socket.on('status_atualizado', function(data) {
             console.log('Status de chamado atualizado:', data);
-            if (window.advancedNotificationSystem) {
-                window.advancedNotificationSystem.showInfo(
-                    'Status Atualizado',
-                    `Chamado ${data.codigo} alterado para ${data.novo_status}`
-                );
-            }
+            // Notificação visual já é tratada em notificacoes.js
             // Recarregar dados se necessário
             if (document.getElementById('gerenciar-chamados').classList.contains('active')) {
                 loadChamados();
@@ -2807,12 +2805,7 @@ function initializeSocketIO() {
 
         socket.on('chamado_deletado', function(data) {
             console.log('Chamado deletado:', data);
-            if (window.advancedNotificationSystem) {
-                window.advancedNotificationSystem.showWarning(
-                    'Chamado Excluído',
-                    `Chamado ${data.codigo} foi exclu��do`
-                );
-            }
+            // Notificação visual já é tratada em notificacoes.js
             // Recarregar dados se necessário
             if (document.getElementById('gerenciar-chamados').classList.contains('active')) {
                 loadChamados();
@@ -2821,12 +2814,7 @@ function initializeSocketIO() {
 
         socket.on('usuario_criado', function(data) {
             console.log('Usuário criado:', data);
-            if (window.advancedNotificationSystem) {
-                window.advancedNotificationSystem.showSuccess(
-                    'Novo Usuário',
-                    `Usuário ${data.nome} ${data.sobrenome} foi criado`
-                );
-            }
+            // Notificação visual já é tratada em notificacoes.js
         });
 
         socket.on('chamado_atribuido', function(data) {
@@ -2869,9 +2857,10 @@ function initializeSocketIO() {
 
         // Disponibilizar socket globalmente
         window.socket = socket;
-        
+        painelSocketInitialized = true;
+
         console.log('Socket.IO inicializado com sucesso');
-        
+
     } catch (error) {
         console.error('Erro ao inicializar Socket.IO:', error);
         updateSocketStatus('Erro de Inicialização', 'danger');
@@ -4908,7 +4897,7 @@ async function confirmarAtribuicao(chamadoId) {
 
         fecharModalAgente();
 
-        // Recarregar chamados para mostrar a atribui��ão
+        // Recarregar chamados para mostrar a atribui����ão
         await loadChamados();
 
     } catch (error) {


### PR DESCRIPTION
## Purpose

The user reported a critical issue where notifications were appearing multiple times on screen when saving information in painel.html or changing card statuses, causing the notifications to cover the entire screen. The goal was to fix the duplicate notification error and ensure only one notification appears correctly.

## Code changes

- **Added Socket.IO initialization guard**: Introduced `painelSocketInitialized` flag to prevent multiple Socket.IO initializations
- **Removed duplicate notification calls**: Removed redundant `advancedNotificationSystem` calls from Socket.IO event handlers (`notification_test`, `status_atualizado`, `chamado_deletado`, `usuario_criado`)
- **Centralized notification handling**: Added comments indicating that visual notifications are now handled in `notificacoes.js` to avoid duplication
- **Improved initialization logic**: Added check to skip re-initialization if socket is already initialized and active

These changes prevent the Socket.IO connection from being initialized multiple times and eliminate duplicate notification displays while maintaining the core functionality.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/866ac3b09b1c401baaee3f4bd025f9dd/curry-studio)

👀 [Preview Link](https://866ac3b09b1c401baaee3f4bd025f9dd-curry-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>866ac3b09b1c401baaee3f4bd025f9dd</projectId>-->
<!--<branchName>curry-studio</branchName>-->